### PR TITLE
Add Heroku postbuild script for building HMRC assets on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "hmrc": "cd ./node_modules/assets-frontend; ./server.sh build; cd -;",
+    "heroku-postbuild": "npm run hmrc",
     "prestart": "npm run hmrc",
     "start": "node start.js"
   },


### PR DESCRIPTION
# Problem

When deploying to Heroku, requests to `/public/*` for HMRC assets were resulting in `404`s.

This was being caused by the fact that Heroku runs `npm install` followed by the command in the Procfile rather than `npm start`. The `npm run hmrc` task therefore wasn't being run (as an `npm prestart` script) so no assets were being built.
# Solution

Adding a `postinstall` script would have resulted in `npm` running the assets-frontend build task twice the first time the prototype kit was cloned. Once after `npm install` and again before `npm start`.
Fortunately Heroku offers hooks into its build process, so a `heroku-postbuild` npm script was added instead that compiles the HMRC assets after a successful build during deployment.
