### PR TITLE
serve the public assets found in hmrc/govuk_elements/govuk/public

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,6 +55,7 @@ nunjucks.ready(function(nj) {
 app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets'));
 app.use('/public', express.static(__dirname + '/hmrc_modules'));
+app.use('/public', express.static(__dirname + '/hmrc_modules/govuk_elements/govuk/public'));
 
 // Elements refers to icon folder instead of images folder
 app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images','favicon.ico')));


### PR DESCRIPTION
# hmrc/govuk_elements/govuk/public

The assets found in `hmrc/govuk_elements/govuk/public` were not being served. This now serves them.
