### PR TITLE
Watch and sync changes in assets/javascripts and assets/images to public directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,23 +27,15 @@ module.exports = function(grunt){
 
     // Copies templates and assets from external modules and dirs
     sync: {
-			assets_js: {
+			assets: {
 				files: [{
-					cwd: 'app/assets',
-					src: [
-						'javascripts/**'
-					],
+					expand: true,
+					cwd: 'app/assets/',
+					src: ['**/*', '!sass/**'],
 					dest: 'public/'
-				}]
-			},
-			assets_images: {
-				files: [{
-					cwd: 'app/assets',
-					src: [
-						'images/**'
-					],
-					dest: 'public/'
-				}]
+				}],
+				ignoreInDest: "**/stylesheets/**",
+				updateAndDelete: true
 			},
       hmrc: {
         files: [{
@@ -93,21 +85,14 @@ module.exports = function(grunt){
         files: ['app/assets/sass/**/*.scss'],
         tasks: ['sass'],
         options: {
-          spawn: false,
+          spawn: false
         }
       },
-			js: {
-				files: ['app/assets/javascripts/*.js'],
-				tasks: ['sync:assets_js'],
+			assets:{
+				files: ['app/assets/**/*', '!app/assets/sass/**'],
+				tasks: ['sync:assets'],
 				options: {
-					spawn: false,
-				}
-			},
-			images: {
-				files: ['app/assets/images/**'],
-				tasks: ['sync:assets_images'],
-				options: {
-					spawn: false,
+					spawn: false
 				}
 			}
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,24 @@ module.exports = function(grunt){
 
     // Copies templates and assets from external modules and dirs
     sync: {
+			assets_js: {
+				files: [{
+					cwd: 'app/assets',
+					src: [
+						'javascripts/**'
+					],
+					dest: 'public/'
+				}]
+			},
+			assets_images: {
+				files: [{
+					cwd: 'app/assets',
+					src: [
+						'images/**'
+					],
+					dest: 'public/'
+				}]
+			},
       hmrc: {
         files: [{
           cwd: 'node_modules/assets-frontend/assets/',
@@ -77,7 +95,21 @@ module.exports = function(grunt){
         options: {
           spawn: false,
         }
-      }
+      },
+			js: {
+				files: ['app/assets/javascripts/*.js'],
+				tasks: ['sync:assets_js'],
+				options: {
+					spawn: false,
+				}
+			},
+			images: {
+				files: ['app/assets/images/**'],
+				tasks: ['sync:assets_images'],
+				options: {
+					spawn: false,
+				}
+			}
     },
 
     // nodemon watches for changes and restarts app

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -1,0 +1,5 @@
+/**
+ * Add prototype js here - this file is included in scripts.html and will be available on every
+ * page of the prototype
+ *
+ */

--- a/app/assets/javascripts/prototype.js
+++ b/app/assets/javascripts/prototype.js
@@ -1,0 +1,5 @@
+/**
+ * Add prototype js here - this file is included in scripts.html and will be avaialble on every
+ * page of the prototype
+ *
+ */

--- a/app/assets/javascripts/prototype.js
+++ b/app/assets/javascripts/prototype.js
@@ -1,5 +1,0 @@
-/**
- * Add prototype js here - this file is included in scripts.html and will be avaialble on every
- * page of the prototype
- *
- */

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,3 +1,6 @@
 <!-- HMRC JavaScript -->
 <script src="/public/javascripts/vendor/modernizr.js"></script>
 <script src="/public/javascripts/application.min.js"></script>
+
+<script src="/public/javascripts/prototype.js"></script>
+

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -2,5 +2,5 @@
 <script src="/public/javascripts/vendor/modernizr.js"></script>
 <script src="/public/javascripts/application.min.js"></script>
 
-<script src="/public/javascripts/prototype.js"></script>
+<script src="/public/javascripts/app.js"></script>
 


### PR DESCRIPTION
The prototype kit is correctly watching and syncing changes in assets/sass -> public/stylesheets but was not doing the same for assets/javascripts or assets/images. Modified gruntfile to watch for changes in assets javascript and images and sync them into the public directory. Also added a default app.js file in assets/javascripts which is included in scripts.html so that it is available out-of-the-box in a fresh clone of the kit.
