### PR TITLE
Fix assets-frontend build script for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=4.0 <5.0"
   },
   "scripts": {
-    "hmrc": "cd ./node_modules/assets-frontend; ./server.sh build; cd -;",
+    "hmrc": "node scripts/hmrc-build.js",
     "heroku-postbuild": "npm run hmrc",
     "prestart": "npm run hmrc",
     "start": "node start.js"

--- a/scripts/hmrc-build.js
+++ b/scripts/hmrc-build.js
@@ -1,0 +1,16 @@
+var path = require('path');
+var spawn = require('child_process').spawn;
+
+var filepath = path.resolve('node_modules', 'assets-frontend');
+
+var build = spawn('./server.sh', ['build'], {
+  cwd: filepath
+});
+
+build.stdout.on('data', function(data) {
+  process.stdout.write(data.toString());
+});
+
+build.stderr.on('data', function(data) {
+  process.stdout.write(data.toString());
+});

--- a/scripts/hmrc-build.js
+++ b/scripts/hmrc-build.js
@@ -1,10 +1,13 @@
 var path = require('path');
-var spawn = require('child_process').spawn;
+var exec = require('child_process').exec
 
 var filepath = path.resolve('node_modules', 'assets-frontend');
 
-var build = spawn('./server.sh', ['build'], {
-  cwd: filepath
+var build = exec('./server.sh build', {cwd: filepath}, function (error, stdout, stderr) {
+  if (error) {
+    console.error('exec error:' + error);
+    return;
+  }
 });
 
 build.stdout.on('data', function(data) {


### PR DESCRIPTION
## Problem

Windows was throwing up when trying to run `npm run hmrc`. The problem turned out to be the forward slashes in the path for `cd`.
## Solution

Don't rely on hardcoded paths, use node's `path.resolve` instead.
