### PR TITLE
Fix shell script execution for windows

### DIFF
--- a/scripts/hmrc-build.js
+++ b/scripts/hmrc-build.js
@@ -3,7 +3,7 @@ var exec = require('child_process').exec
 
 var filepath = path.resolve('node_modules', 'assets-frontend');
 
-var build = exec('./server.sh build', {cwd: filepath}, function (error, stdout, stderr) {
+var build = exec('sh server.sh build', {cwd: filepath}, function (error, stdout, stderr) {
   if (error) {
     console.error('exec error:' + error);
     return;


### PR DESCRIPTION
## Problem

We were still seeing the following error in windows...
![image](https://cloud.githubusercontent.com/assets/1752124/16651426/b8eed1e2-443b-11e6-943e-8af22b26a09b.png)
## Solution

Windows can't dot source scripts so we need call the the `servser.sh` script explicitly
