### PR TITLE
fix the path to server.sh for cross platform users :boom:

### DIFF
--- a/scripts/hmrc-build.js
+++ b/scripts/hmrc-build.js
@@ -1,9 +1,8 @@
 var path = require('path');
 var exec = require('child_process').exec
+var assetsFrontendRoot = path.resolve('node_modules', 'assets-frontend');
 
-var filepath = path.resolve('node_modules', 'assets-frontend');
-
-var build = exec('./server.sh build', {cwd: filepath}, function (error, stdout, stderr) {
+var build = exec('npm run build', {cwd: assetsFrontendRoot}, function (error, stdout, stderr) {
   if (error) {
     console.error('exec error:' + error);
     return;


### PR DESCRIPTION
This work makes the `hmrc-build.js` script cross-platform compatible
