### PR TITLE
Add grunt-post-css and autoprefixer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,17 @@ module.exports = function (grunt) {
       }
     },
 
+    postcss: {
+      options: {
+        processors: [
+          require('autoprefixer')({browsers: ['last 2 versions', 'IE >= 8']}),
+        ]
+      },
+      dist: {
+        src: 'public/stylesheets/*.css'
+      }
+    },
+
     // Copies templates and assets from external modules and dirs
     sync: {
       assets: {
@@ -123,6 +134,7 @@ module.exports = function (grunt) {
     'grunt-sync',
     'grunt-contrib-watch',
     'grunt-sass',
+    'grunt-postcss',
     'grunt-nodemon',
     'grunt-concurrent'
   ].forEach(function (task) {
@@ -131,7 +143,8 @@ module.exports = function (grunt) {
 
   grunt.registerTask('generate-assets', [
     'sync',
-    'sass'
+    'sass',
+    'postcss'
   ]);
 
   grunt.registerTask('default', [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "node start.js"
   },
   "dependencies": {
+    "autoprefixer": "^6.4.1",
     "basic-auth": "^1.0.3",
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
@@ -28,6 +29,7 @@
     "grunt-concurrent": "0.4.3",
     "grunt-contrib-watch": "0.5.3",
     "grunt-nodemon": "0.4.0",
+    "grunt-postcss": "^0.8.0",
     "grunt-sass": "^1.1.0",
     "grunt-sync": "^0.5.1",
     "hogan.js": "3.0.2",


### PR DESCRIPTION
# Autoprefix styles with vendor prefixes

Add autoprefixer `['last 2 versions', 'IE >= 8']` to mimic the sass process found in the `sass` gulp build in [assets-frontend](https://github.com/hmrc/assets-frontend/blob/master/gulpfile.js/tasks/sass.js#L24)

FYI - @russell-hmrc 
### Generated styles

![screen shot 2016-09-21 at 11 43 14](https://cloud.githubusercontent.com/assets/2305016/18708025/b938269e-7ff0-11e6-91ff-114e537add0a.png)
